### PR TITLE
Fix path helper and documentation in utils

### DIFF
--- a/qlib/utils/file.py
+++ b/qlib/utils/file.py
@@ -34,7 +34,12 @@ def get_or_create_path(path: Optional[Text] = None, return_dir: bool = False):
         if not os.path.exists(temp_dir):
             os.makedirs(temp_dir)
         if return_dir:
-            _, path = tempfile.mkdtemp(dir=temp_dir)
+            # `mkdtemp` returns the created directory path directly, while `mkstemp`
+            # returns a tuple of `(fd, path)`.  The previous implementation tried to
+            # unpack the return value of `mkdtemp` into two variables, which raises a
+            # `ValueError` at runtime.  This branch should therefore assign the path
+            # directly without unpacking.
+            path = tempfile.mkdtemp(dir=temp_dir)
         else:
             _, path = tempfile.mkstemp(dir=temp_dir)
     return path

--- a/qlib/utils/index_data.py
+++ b/qlib/utils/index_data.py
@@ -11,15 +11,15 @@ Motivation of index_data
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Union, Callable, List
+from typing import Dict, Tuple, Callable, List
 import bisect
 
 import numpy as np
 import pandas as pd
 
 
-def concat(data_list: Union[SingleData], axis=0) -> MultiData:
-    """concat all SingleData by index.
+def concat(data_list: List["SingleData"], axis=0) -> "MultiData":
+    """Concat multiple :class:`SingleData` objects by index.
     TODO: now just for SingleData.
 
     Parameters
@@ -54,8 +54,8 @@ def concat(data_list: Union[SingleData], axis=0) -> MultiData:
         raise ValueError(f"axis must be 0 or 1")
 
 
-def sum_by_index(data_list: Union[SingleData], new_index: list, fill_value=0) -> SingleData:
-    """concat all SingleData by new index.
+def sum_by_index(data_list: List["SingleData"], new_index: list, fill_value=0) -> "SingleData":
+    """Sum all ``SingleData`` instances into a new index.
 
     Parameters
     ----------

--- a/qlib/utils/mod.py
+++ b/qlib/utils/mod.py
@@ -3,7 +3,7 @@
 """
 All module related class, e.g. :
 - importing a module, class
-- walkiing a module
+- walking a module
 - operations on class or module...
 """
 

--- a/tests/misc/test_file_utils.py
+++ b/tests/misc/test_file_utils.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+
+from qlib.utils.file import get_or_create_path
+
+
+def test_get_or_create_path_none_dir(tmp_path):
+    # When no path is provided, a temporary directory should be created
+    created = get_or_create_path(return_dir=True)
+    assert os.path.isdir(created)
+    # cleanup
+    os.rmdir(created)
+
+
+def test_get_or_create_path_creates_parent(tmp_path):
+    # When a file path is provided, the parent directory should be created
+    file_path = tmp_path / "a" / "b" / "c.txt"
+    result = get_or_create_path(str(file_path))
+    assert Path(result) == file_path
+    assert file_path.parent.is_dir()


### PR DESCRIPTION
## Summary
- fix get_or_create_path to handle directory creation correctly
- clarify index data utilities and correct spelling in module utils
- add regression tests for get_or_create_path helper

## Testing
- `python -m pytest tests/misc/test_file_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a67a8ee59883318a99f37a8aea4919